### PR TITLE
Add demo login button for judges

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -35,6 +35,30 @@ export function LoginForm() {
         }
     }
 
+    const handleDemoLogin = async () => {
+        const demoEmail = process.env.NEXT_PUBLIC_DEMO_EMAIL
+        const demoPassword = process.env.NEXT_PUBLIC_DEMO_PASSWORD
+
+        if (!demoEmail || !demoPassword) {
+            form.setError('root', { message: 'Demo credentials not configured' })
+            return
+        }
+
+        try {
+            const { error } = await supabase.auth.signInWithPassword({
+                email: demoEmail,
+                password: demoPassword,
+            })
+            if (error) {
+                form.setError('root', { message: error.message })
+            } else {
+                router.push('/dashboard')
+            }
+        } catch {
+            form.setError('root', { message: 'An unexpected error occurred' })
+        }
+    }
+
     return (
         <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="max-w-sm w-full space-y-3">
@@ -73,6 +97,23 @@ export function LoginForm() {
                     className="w-full"
                 >
                     {form.formState.isSubmitting ? 'Signing in...' : 'Sign In'}
+                </Button>
+                <div className="relative">
+                    <div className="absolute inset-0 flex items-center">
+                        <span className="w-full border-t" />
+                    </div>
+                    <div className="relative flex justify-center text-xs uppercase">
+                        <span className="bg-white px-2 text-gray-500">Or</span>
+                    </div>
+                </div>
+                <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleDemoLogin}
+                    disabled={form.formState.isSubmitting}
+                    className="w-full"
+                >
+                    Demo Login (For Judges)
                 </Button>
                 <p className="text-sm text-gray-600 text-center">
                     No account? <Link href="/signup" className="text-blue-600 hover:underline">Create one</Link>


### PR DESCRIPTION
Added a one-click demo login button to the login form to make it easier for judges to test the application without needing to create an account or remember credentials.

Changes:
- Added handleDemoLogin function that uses environment variables for demo credentials
- Added "Demo Login (For Judges)" button with divider below regular sign-in
- Button uses demo credentials from NEXT_PUBLIC_DEMO_EMAIL and NEXT_PUBLIC_DEMO_PASSWORD

🤖 Generated with [Claude Code](https://claude.com/claude-code)